### PR TITLE
Fix air quality measurement duration

### DIFF
--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -107,7 +107,7 @@ boolean Adafruit_SGP30::IAQmeasure(void) {
   command[0] = 0x20;
   command[1] = 0x08;
   uint16_t reply[2];
-  if (! readWordFromCommand(command, 2, 10, reply, 2))
+  if (! readWordFromCommand(command, 2, 12, reply, 2))
     return false;
   TVOC = reply[1];
   eCO2 = reply[0];


### PR DESCRIPTION
The duration for an air quality measurement is 50ms.

Please see the data sheet (https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9_Gas_Sensors/Sensirion_Gas_Sensors_SGP30_Datasheet_EN.pdf, page 9, Table 10) for the detailed description.