### PR TITLE
Set baseline command does not provide any response

### DIFF
--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -153,10 +153,7 @@ boolean Adafruit_SGP30::setIAQBaseline(uint16_t eco2_base, uint16_t tvoc_base) {
   command[6] = eco2_base & 0xFF;
   command[7] = generateCRC(command+5, 2);
 
-  uint16_t reply[2];
-  if (! readWordFromCommand(command, 8, 10, reply, 0))
-    return false;
-  return true;
+  return readWordFromCommand(command, 8, 10);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Since the set baseline command does not provide an answer no reply array is needed. The readWordFromCommand is called with reply_len 0, hence, the function (correctly) does not try to read a response. Hence, the reply array is removed.