### PR TITLE
Add humidity compensation

### DIFF
--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -157,6 +157,29 @@ boolean Adafruit_SGP30::setIAQBaseline(uint16_t eco2_base, uint16_t tvoc_base) {
 }
 
 /**************************************************************************/
+/*!
+    @brief Set the absolute humidity value [mg/m^3] for compensation to increase precision of TVOC and eCO2.
+    @param absolute_humidity A uint32_t [mg/m^3] which we will be used for compensation. If the absolute humidity is set to zero, humidity compensation will be disabled.
+    @returns True if command completed successfully, false if something went wrong!
+*/
+/**************************************************************************/
+boolean SensirionSGP30::setHumidity(uint32_t absolute_humidity) {
+  if (absolute_humidity > 256000) {
+    return false;
+  }
+
+  uint16_t ah_scaled = (uint16_t)(((uint64_t)absolute_humidity * 256 * 16777) >> 24);
+  uint8_t command[5];
+  command[0] = 0x20;
+  command[1] = 0x61;
+  command[2] = ah_scaled >> 8;
+  command[3] = ah_scaled & 0xFF;
+  command[4] = generateCRC(command+2, 2);
+
+  return readWordFromCommand(command, 5, 10);
+}
+
+/**************************************************************************/
 /*! 
     @brief  I2C low level interfacing
 */

--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -163,7 +163,7 @@ boolean Adafruit_SGP30::setIAQBaseline(uint16_t eco2_base, uint16_t tvoc_base) {
     @returns True if command completed successfully, false if something went wrong!
 */
 /**************************************************************************/
-boolean SensirionSGP30::setHumidity(uint32_t absolute_humidity) {
+boolean Adafruit_SGP30::setHumidity(uint32_t absolute_humidity) {
   if (absolute_humidity > 256000) {
     return false;
   }

--- a/Adafruit_SGP30.h
+++ b/Adafruit_SGP30.h
@@ -42,6 +42,7 @@ class Adafruit_SGP30 {
 
   boolean getIAQBaseline(uint16_t *eco2_base, uint16_t *tvoc_base);
   boolean setIAQBaseline(uint16_t eco2_base, uint16_t tvoc_base);
+  boolean setHumidity(uint32_t absolute_humidity);
 
   /**
    * The last measurement of the IAQ-calculated Total Volatile Organic Compounds in ppb. This value is set when you call {@link IAQmeasure()}

--- a/examples/sgp30test/sgp30test.ino
+++ b/examples/sgp30test/sgp30test.ino
@@ -3,6 +3,17 @@
 
 Adafruit_SGP30 sgp;
 
+/* return absolute humidity [mg/m^3] with approximation formula
+* @param temperature [°C]
+* @param humidity [%RH]
+*/
+uint32_t getAbsoluteHumidity(float temperature, float humidity) {
+    // approximation formula from Sensirion SGP30 Driver Integration chapter 3.15
+    const float absoluteHumidity = 216.7f * ((humidity / 100.0f) * 6.112f * exp((17.62f * temperature) / (243.12f + temperature)) / (273.15f + temperature)); // [g/m^3]
+    const uint32_t absoluteHumidityScaled = static_cast<uint32_t>(1000.0f * absoluteHumidity); // [mg/m^3]
+    return absoluteHumidityScaled;
+}
+
 void setup() {
   Serial.begin(9600);
   Serial.println("SGP30 test");
@@ -22,6 +33,11 @@ void setup() {
 
 int counter = 0;
 void loop() {
+  // If you have a temperature / humidity sensor, you can set the absolute humidity to enable the humditiy compensation for the air quality signals
+  //float temperature = 22.1; // [°C]
+  //float humidity = 45.2; // [%RH]
+  //sgp.setHumidity(getAbsoluteHumidity(temperature, humidity));
+
   if (! sgp.IAQmeasure()) {
     Serial.println("Measurement failed");
     return;


### PR DESCRIPTION
The SGP30 features an on-chip humidity compensation for the air quality signals (CO2eq and TVOC) and sensor raw signals (H2-signal and Ethanol_signal).
To use the on-chip humidity compensation an absolute humidity value from an external humidity sensor like the SHTxx is required.