### PR TITLE
Added inclusion guard to Adafruit_SGP30.h

### DIFF
--- a/Adafruit_SGP30.h
+++ b/Adafruit_SGP30.h
@@ -81,4 +81,4 @@ private:
                               uint8_t readlen = 0);
   uint8_t generateCRC(uint8_t data[], uint8_t datalen);
 };
-#endif //ndef ADAFRUIT_SGP30_H
+#endif // ndef ADAFRUIT_SGP30_H

--- a/Adafruit_SGP30.h
+++ b/Adafruit_SGP30.h
@@ -18,6 +18,9 @@
  *
  */
 
+#ifndef ADAFRUIT_SGP30_H
+#define ADAFRUIT_SGP30_H
+
 #include "Arduino.h"
 #include <Wire.h>
 
@@ -78,3 +81,4 @@ private:
                               uint8_t readlen = 0);
   uint8_t generateCRC(uint8_t data[], uint8_t datalen);
 };
+#endif //ndef ADAFRUIT_SGP30_H


### PR DESCRIPTION

I added an inclusion guard to Adafruit_SGP30.h . This allows for using this library within other libraries easier, by preventing multiple inclusions - you can now include this file in many files in the same project. There are no known limitations.
