### PR TITLE
Fixed soft reset command

### DIFF
--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -74,14 +74,11 @@ boolean Adafruit_SGP30::begin(TwoWire *theWire) {
  * Call" mode. Take note that this is not sensor specific and all devices that
  * support the General Call mode on the on the same I2C bus will perform this.
  *
- *   @return True if command completed successfully, false if something went
- *           wrong!
  */
-boolean Adafruit_SGP30::softReset(void) {
-  uint8_t command[2];
-  command[0] = 0x00;
-  command[1] = 0x06;
-  return readWordFromCommand(command, 2, 10);
+void Adafruit_SGP30::softReset(void) {
+  _i2c->beginTransmission(0x00);
+  _i2c->write(0x06);
+  _i2c->endTransmission();
 }
 
 /*!

--- a/Adafruit_SGP30.h
+++ b/Adafruit_SGP30.h
@@ -38,7 +38,7 @@ class Adafruit_SGP30 {
 public:
   Adafruit_SGP30();
   boolean begin(TwoWire *theWire = &Wire);
-  boolean softReset();
+  void softReset();
   boolean IAQinit();
   boolean IAQmeasure();
   boolean IAQmeasureRaw();


### PR DESCRIPTION
This is to fix the soft reset function as noted out in this issure here. #19 

Changed the `softReset()` function from using the `readWordCommand` to using the TwoWire commands to implement the soft reset using the General Call mode by using `0x00` as the I2C address instead of the SGP30 device address as previously used. 