### PR TITLE
Fix 'softReset()' using general reset call

### DIFF
--- a/Adafruit_SGP30.cpp
+++ b/Adafruit_SGP30.cpp
@@ -82,14 +82,16 @@ boolean Adafruit_SGP30::begin(TwoWire *theWire, boolean initSensor) {
  * Call" mode. Take note that this is not sensor specific and all devices that
  * support the General Call mode on the on the same I2C bus will perform this.
  *
- *   @return True if command completed successfully, false if something went
- *           wrong!
+ *  @param  theWire
+ *          Optional pointer to I2C interface, otherwise use Wire
+ * 
+ *  @return True if command completed successfully, false if something went
+ *          wrong!
  */
-boolean Adafruit_SGP30::softReset(void) {
-  uint8_t command[2];
-  command[0] = 0x00;
-  command[1] = 0x06;
-  return readWordFromCommand(command, 2, 10);
+boolean Adafruit_SGP30::softReset(TwoWire* theWire) {
+  theWire->beginTransmission(0x00);
+  theWire->write(0x06);
+  return !(theWire->endTransmission());
 }
 
 /*!

--- a/Adafruit_SGP30.h
+++ b/Adafruit_SGP30.h
@@ -42,7 +42,7 @@ class Adafruit_SGP30 {
 public:
   Adafruit_SGP30();
   boolean begin(TwoWire *theWire = &Wire, boolean initSensor = true);
-  boolean softReset();
+  boolean softReset(TwoWire *theWire = &Wire);
   boolean IAQinit();
   boolean IAQmeasure();
   boolean IAQmeasureRaw();


### PR DESCRIPTION
Updated the 'softReset()' call to perform a 'general reset' on the I2c bus according to the SGP30 datasheet. Since the stored `i2c` device fixes the target address, the current solution does not work. Therefore, an optional `theWire` parameter is added to allow direct bus access.

Power consumption after including the revised function dropped from 48 ma to expected ESP32 deep sleep levels, indicating success. 

This PR resolves #28 and #20 
